### PR TITLE
バグ修正

### DIFF
--- a/Assets/UniBagOfWords/Scripts/BagOfWords/BagOfWordsConverter.cs
+++ b/Assets/UniBagOfWords/Scripts/BagOfWords/BagOfWordsConverter.cs
@@ -22,7 +22,7 @@ namespace UniBagOfWords
             var vec = new int[_vocabulary.Count];
             foreach(var morpheme in morphemes)
             {
-                var index = _vocabulary.GetId(morpheme.Originalform);
+                var index = _vocabulary.GetId(morpheme.Surface);
 
                 if (index != -1) vec[index]++;
             }


### PR DESCRIPTION
単語辞書側ではSurfaceにしたが，Converter実行時ではOriginalformを使って比較していたため